### PR TITLE
use sinon.test() inside it()

### DIFF
--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -32,6 +32,14 @@
     }
   };
   
+  if (global.it) {
+    var jasmineIt = global.it;
+    
+    global.it = function(desc, func) {
+      jasmineIt(desc, sinon.test(func));
+    };
+  }
+  
 })(window);
 
 beforeEach(function() {


### PR DESCRIPTION
should be able to use this.spy() etc inside it()
sinon will clean them up automatically as long as you use this.\* and not sinon.*
