### PR TITLE
adding sinon sandbox creation and clean up for every spec.  

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -8,10 +8,12 @@
   <script src="lib/jasmine-1.1.0/jasmine-html.js"></script>
   <script src="lib/sinon-1.3.1/sinon-1.3.1.js"></script>
   <script src="lib/jasmine-sinon.js"></script>
+  <script src="lib/jasmine-sinon-sandbox.js"></script>
 
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 
   <script src="spec/jasmine-sinon-specs.js"></script>
+  <script src="spec/jasmine-sinon-sandbox-specs.js"></script>
 
 </head>
 <body>

--- a/lib/jasmine-sinon-sandbox.js
+++ b/lib/jasmine-sinon-sandbox.js
@@ -1,0 +1,9 @@
+var sb;
+beforeEach(function() {
+	sb = sinon.sandbox.create();
+	
+});
+
+afterEach(function() {
+	sb.restore();
+});

--- a/spec/jasmine-sinon-sandbox-specs.js
+++ b/spec/jasmine-sinon-sandbox-specs.js
@@ -1,0 +1,30 @@
+describe("autoload sinon sandbax", function() {
+	it("has a sandbox in every test", function() {
+		expect(sb).toBeDefined();
+	});
+	
+	
+	describe("sandbox is cleaned up after every test", function() {
+		SOME_GLOBAL_OBJECT = {
+			a_function: function() {}
+		}
+		it("spying on a global object", function() {
+			sb.spy(SOME_GLOBAL_OBJECT, 'a_function');
+			
+			SOME_GLOBAL_OBJECT.a_function();
+			
+			expect(SOME_GLOBAL_OBJECT.a_function).toHaveBeenCalledOnce();
+			
+		});
+		
+		it("spying on a global object again", function() {
+			sb.spy(SOME_GLOBAL_OBJECT, 'a_function');
+			
+			SOME_GLOBAL_OBJECT.a_function();
+			
+			expect(SOME_GLOBAL_OBJECT.a_function).toHaveBeenCalledOnce();
+			
+		});
+	})
+	
+});


### PR DESCRIPTION
I have found this allows you to spy on or stub behaviour of other classes and safely restore the environment for the next spec.

the sandbox is available in the sb variable.   

Just use sb.spy(....) and it will be cleaned up automatically for you after each spec
