### PR TITLE
Jasmine matchers toHaveBeenCalled and toHaveBeenCalledWith gracefully overridden.

### DIFF
--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -10,8 +10,12 @@
       "alwaysThrew": "toHaveAlwaysThrown"
     },
 
-  getMatcherFunction = function(sinonName) {
-    return function() {
+  getMatcherFunction = function(sinonName, matcherName) {
+    var original = jasmine.Matchers.prototype[matcherName];
+    return function () {
+      if (jasmine.isSpy(this.actual) && original) {
+        return original.apply(this, arguments);
+      }
       var sinonProperty = this.actual[sinonName];
       return (typeof sinonProperty === 'function') ? sinonProperty.apply(this.actual, arguments) : sinonProperty;
     };
@@ -21,11 +25,11 @@
     var sinonName = spyMatchers[i],
       matcherName = "toHaveBeen" + sinonName.charAt(0).toUpperCase() + sinonName.slice(1);
 
-    spyMatcherHash[matcherName] = getMatcherFunction(sinonName);
+    spyMatcherHash[matcherName] = getMatcherFunction(sinonName, matcherName);
   };
 
   for (var j in unusualMatchers) {
-    spyMatcherHash[unusualMatchers[j]] = getMatcherFunction(j);
+    spyMatcherHash[unusualMatchers[j]] = getMatcherFunction(j, unusualMatchers[j]);
   }
 
   global.sinonJasmine = {

--- a/spec/jasmine-sinon-specs.js
+++ b/spec/jasmine-sinon-specs.js
@@ -186,7 +186,7 @@ describe("jasmine-sinon", function() {
         this.spy.call({});
         expect(this.spy.alwaysCalledOn(this)).toBeFalsy();
         expect(this.spy).not.toHaveBeenAlwaysCalledOn(this);
-      })
+      });
 
     });
 
@@ -554,7 +554,7 @@ describe("jasmine-sinon", function() {
         myMethod: function(val) {
           this.methodVal = val;
         }
-      }
+      };
       this.spy = sinon.spy(this.api, "myMethod");
     });
 
@@ -645,7 +645,7 @@ describe("jasmine-sinon", function() {
         foo: function() {
           return 'bar';
         }
-      }
+      };
       this.methodStub = sinon.stub(this.api,'foo');
     });
 
@@ -694,4 +694,37 @@ describe("jasmine-sinon", function() {
 
   });
 
+  describe("jasmine matchers gracefully overridden", function() {
+
+    beforeEach(function() {
+      this.methodVal = "no";
+      this.api = {
+        myMethod: function(val) {
+          this.methodVal = val;
+        }
+      };
+      spyOn(this.api, "myMethod").andCallThrough();
+    });
+    
+    describe("toHaveBeenCalled", function() {
+      it("should work for jasmine spy", function() {
+        expect(this.methodVal).toEqual("no");
+        expect(this.api.myMethod).not.toHaveBeenCalled();
+        this.api.myMethod.call(this, "yes");
+        expect(this.methodVal).toEqual("yes");
+        expect(this.api.myMethod).toHaveBeenCalled();
+      });
+    });
+    
+    describe("toHaveBeenCalledWith", function() {
+      it("should work for jasmine spy", function() {
+        expect(this.methodVal).toEqual("no");
+        expect(this.api.myMethod).not.toHaveBeenCalledWith("yes");
+        this.api.myMethod.call(this, "yes");
+        expect(this.methodVal).toEqual("yes");
+        expect(this.api.myMethod).toHaveBeenCalledWith("yes");
+      });
+    });
+    
+  });
 });


### PR DESCRIPTION
Jasmine-Sinon matchers with the same names pass through to original ones when Jasmine spy is passed to expect().
