### PR TITLE
Extended bower ignore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,12 @@
   "ignore": [
     "**/.*",
     "node_modules",
-    "components"
+    "components",
+    "spec",
+    "lib/**/*",
+    "!lib/jasmine-sinon.js",
+    "Gruntfile.js",
+    "karma.conf.js",
+    "package.json"
   ]
 }


### PR DESCRIPTION
Currently installing jasmine-sinon via bower installs a lot of unneeded files, including jasmine and sinon, which are better specified as dependencies. I put all but LICENSE, README and the actual library on the ignore list and added jasmin and sinon as dependencies.
