### PR TITLE
Support for jasmine.any and jasmine.objectContaining

### DIFF
--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -4,7 +4,8 @@
 
 (function(jasmine, beforeEach) {
 
-  var spyMatchers = 'called calledOnce calledTwice calledThrice calledBefore calledAfter calledOn alwaysCalledOn calledWith alwaysCalledWith calledWithExactly alwaysCalledWithExactly calledWithMatch alwaysCalledWithMatch'.split(' '),
+  var sinon = (typeof require === 'function' && typeof module === 'object') ? require('sinon') : window.sinon,
+    spyMatchers = 'called calledOnce calledTwice calledThrice calledBefore calledAfter calledOn alwaysCalledOn calledWith alwaysCalledWith calledWithExactly alwaysCalledWithExactly calledWithMatch alwaysCalledWithMatch'.split(' '),
     i = spyMatchers.length,
     spyMatcherHash = {},
     unusualMatchers = {
@@ -14,6 +15,12 @@
       "alwaysThrew": "toHaveAlwaysThrown"
     },
 
+    createCustomMatcher = function(arg) {
+      return sinon.match(function (val) {
+        return jasmine.getEnv().equals_(val, arg);
+      });
+    },
+
     getMatcherFunction = function(sinonName, matcherName) {
       var original = jasmine.Matchers.prototype[matcherName];
       return function () {
@@ -21,7 +28,15 @@
           return original.apply(this, arguments);
         }
         var sinonProperty = this.actual[sinonName];
-        return (typeof sinonProperty === 'function') ? sinonProperty.apply(this.actual, arguments) : sinonProperty;
+        var args = Array.prototype.slice.call(arguments);
+
+        for (var i = 0; i < args.length; i++) {
+          if (args[i] && (typeof args[i].jasmineMatches === 'function' || args[i] instanceof jasmine.Matchers.ObjectContaining)) {
+            args[i] = createCustomMatcher(args[i]);
+          }
+        }
+
+        return (typeof sinonProperty === 'function') ? sinonProperty.apply(this.actual, args) : sinonProperty;
       };
     };
 

--- a/spec/jasmine-matchers-compatibility.spec.js
+++ b/spec/jasmine-matchers-compatibility.spec.js
@@ -1,0 +1,26 @@
+if (typeof require === 'function' && typeof module === 'object') {
+  var sinon = require('sinon');
+  var jasmineSinon = require('../lib/jasmine-sinon.js');
+}
+
+describe('sinon matchers should support jasmine matchers', function() {
+  it('jasmine.any()', function () {
+    var spy = sinon.spy();
+    spy('abc');
+    spy(new Date());
+    expect(spy).toHaveBeenCalledWith(jasmine.any(String));
+    expect(spy).toHaveBeenCalledWith(jasmine.any(Date));
+    expect(spy).not.toHaveBeenCalledWith(jasmine.any(Number));
+  });
+
+  it('jasmine.objectContaining()', function () {
+    var spy = sinon.spy();
+    spy({
+      a: 1,
+      b: 2,
+      c: 3
+    });
+    expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({b: 2}));
+    expect(spy).not.toHaveBeenCalledWith(jasmine.objectContaining({b: 1}));
+  });
+});


### PR DESCRIPTION
It is common to use jasmine.any() and jasmine.objectContaining() to do fuzzy matching with the "toHaveBeenCalledWith" matcher, and this library should support both sinonjs and jasmine argument matchers when working on sinon spies/stubs.
