### PR TITLE
Jasmine 2 support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -62,7 +62,7 @@
   "predef"        : [
     "beforeEach",
     "jasmine",
-    "jasmineRequire"
+    "jasmineRequire",
     "describe",
     "it",
     "beforeEach",

--- a/.jshintrc
+++ b/.jshintrc
@@ -59,6 +59,6 @@
   "white"         : false,
 
   "maxerr"        : 100,
-  "predef"        : [ "beforeEach" ],
+  "predef"        : [ "beforeEach", "jasmine", "jasmineRequire" ],
   "indent"        : 2
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -59,6 +59,14 @@
   "white"         : false,
 
   "maxerr"        : 100,
-  "predef"        : [ "beforeEach", "jasmine", "jasmineRequire" ],
+  "predef"        : [
+    "beforeEach",
+    "jasmine",
+    "jasmineRequire"
+    "describe",
+    "it",
+    "beforeEach",
+    "afterEach"
+  ],
   "indent"        : 2
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,13 +2,24 @@ module.exports = function(grunt) {
 
   'use strict';
 
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-karma');
+  grunt.loadNpmTasks('grunt-jasmine-node');
+  grunt.loadNpmTasks('grunt-shell');
+
   grunt.initConfig({
-    jasmine_node: {
-      options: {
-        forceExit: true,
-        isVerbose: false
-      },
-      all: ['spec/']
+    // jasmine_node: {
+    //   options: {
+    //     forceExit: true,
+    //     isVerbose: false
+    //   },
+    //   all: ['spec/']
+    // },
+
+    shell: {
+      nodespecs: {
+        command: 'node_modules/.bin/jasmine-node spec/'
+      }
     },
 
     jshint: {
@@ -32,12 +43,8 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-karma');
-  grunt.loadNpmTasks('grunt-jasmine-node');
-
-  grunt.registerTask('test', ['jshint', 'karma:ci', 'jasmine_node']);
+  grunt.registerTask('test', ['jshint', 'karma:ci', 'shell:nodespecs']);
   grunt.registerTask('default', 'test');
-  grunt.registerTask('travis', ['jshint', 'karma:ci', 'jasmine_node']);
+  grunt.registerTask('travis', 'default');
 
 };

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Instead of:
 
 you get:
 
-    Expected Function to have been called.
+    Expected spy "mySpy" to have been called with "foo".
+
+## Jasmine 1.x / 2.x compatibility
+
+If you are using Jasmine 1.x, use the latest 0.3.x release. For Jasmine 2, use 0.4 or above.
 
 ## Installation
 
@@ -60,82 +64,94 @@ In general, you should be able to translate a Sinon spy/stub/mock API method to 
         <th>jasmine-sinon matcher</th>
     </tr>
     <tr>
-        <td>called</td>
-        <td>toHaveBeenCalled</td>
+        <td>`called`</td>
+        <td>`toHaveBeenCalled()`</td>
     </tr>
     <tr>
-        <td>calledOnce</td>
-        <td>toHaveBeenCalledOnce</td>
+        <td>`calledOnce`</td>
+        <td>`toHaveBeenCalledOnce()`</td>
     </tr>
     <tr>
-        <td>calledTwice</td>
-        <td>toHaveBeenCalledTwice</td>
+        <td>`calledTwice`</td>
+        <td>`toHaveBeenCalledTwice()`</td>
     </tr>
     <tr>
-        <td>calledThrice</td>
-        <td>toHaveBeenCalledThrice</td>
+        <td>`calledThrice`</td>
+        <td>`toHaveBeenCalledThrice()`</td>
     </tr>
     <tr>
-        <td>calledBefore()</td>
-        <td>toHaveBeenCalledBefore()</td>
+        <td>`calledBefore()`</td>
+        <td>`toHaveBeenCalledBefore()`</td>
     </tr>
     <tr>
-        <td>calledAfter()</td>
-        <td>toHaveBeenCalledAfter()</td>
+        <td>`calledAfter()`</td>
+        <td>`toHaveBeenCalledAfter()`</td>
     </tr>
     <tr>
-        <td>calledOn()</td>
-        <td>toHaveBeenCalledOn()</td>
+        <td>`calledOn()`</td>
+        <td>`toHaveBeenCalledOn()`</td>
     </tr>
     <tr>
-        <td>alwaysCalledOn()</td>
-        <td>toHaveBeenAlwaysCalledOn()</td>
+        <td>`alwaysCalledOn()`</td>
+        <td>`toHaveBeenAlwaysCalledOn()`</td>
     </tr>
     <tr>
-        <td>calledWith()</td>
-        <td>toHaveBeenCalledWith()</td>
+        <td>`calledWith()`</td>
+        <td>`toHaveBeenCalledWith()`</td>
     </tr>
     <tr>
-        <td>alwaysCalledWith()</td>
-        <td>toHaveBeenAlwaysCalledWith()</td>
+        <td>`alwaysCalledWith()`</td>
+        <td>`toHaveBeenAlwaysCalledWith()`</td>
     </tr>
     <tr>
-        <td>calledWithExactly()</td>
-        <td>toHaveBeenCalledWithExactly()</td>
+        <td>`calledWithExactly()`</td>
+        <td>`toHaveBeenCalledWithExactly()`</td>
     </tr>
     <tr>
-        <td>alwaysCalledWithExactly()</td>
-        <td>toHaveBeenAlwaysCalledWithExactly()</td>
+        <td>`alwaysCalledWithExactly()`</td>
+        <td>`toHaveBeenAlwaysCalledWithExactly()`</td>
     </tr>
     <tr>
-        <td>calledWithMatch()</td>
-        <td>toHaveBeenCalledWithMatch()</td>
+        <td>`calledWithMatch()`</td>
+        <td>`toHaveBeenCalledWithMatch()`</td>
     </tr>
     <tr>
-        <td>alwaysCalledWithMatch()</td>
-        <td>toHaveBeenAlwaysCalledWithMatch()</td>
+        <td>`alwaysCalledWithMatch()`</td>
+        <td>`toHaveBeenAlwaysCalledWithMatch()`</td>
     </tr>
     <tr>
-        <td>returned()</td>
-        <td>toHaveReturned()</td>
+        <td>`calledWithNew`</td>
+        <td>`toHaveBeenCalledWithNew()` `>=v0.4`</td>
     </tr>
     <tr>
-        <td>alwaysReturned()</td>
-        <td>toHaveAlwaysReturned()</td>
+        <td>`neverCalledWith`</td>
+        <td>`toHaveBeenNeverCalledWith()` `>=v0.4`</td>
     </tr>
     <tr>
-        <td>threw()</td>
-        <td>toHaveThrown()</td>
+        <td>`neverCalledWithMatch()`</td>
+        <td>`toHaveBeenNeverCalledWithMatch()` `>=v0.4`</td>
     </tr>
     <tr>
-        <td>alwaysThrew()</td>
-        <td>toHaveAlwaysThrown()</td>
+        <td>`threw()`</td>
+        <td>`toHaveThrown()`</td>
+    </tr>
+    <tr>
+        <td>`alwaysThrew()`</td>
+        <td>`toHaveAlwaysThrown()`</td>
+    </tr>
+    <tr>
+        <td>`returned()`</td>
+        <td>`toHaveReturned()`</td>
+    </tr>
+    <tr>
+        <td>`alwaysReturned()`</td>
+        <td>`toHaveAlwaysReturned()`</td>
     </tr>
 </table>
 
 These matchers will work on spies, individual spy calls, stubs and mocks.
 
-You can also use Jasmine spies alongside your Sinon spies. _jasmine-sinon_ will detect which you're using and use the appropriate matcher.
+You can use Jasmine spies alongside your Sinon spies. _jasmine-sinon_ will detect which you're using and use the appropriate matcher.
 
 You can also use Jasmine's fuzzy matchers `any()` and `objectContaining()` in expectations, e.g.
 
@@ -152,3 +168,4 @@ Thanks to:
 * @theinterned for, er, match matchers
 * @milichev for graceful spy matchers
 * @reinseth for Jasmine fuzzy matcher support
+* @stoodder for initial Jasmine 2.0 support work

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "components"
   ],
   "dependencies": {
-    "jasmine": "~1.3.1",
+    "jasmine": "~2.0.0",
     "sinonjs": ">= 1.7.1"
   }
 }

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -9,8 +9,6 @@
     sinon = window.sinon;
   }
 
-  var jasmineSinonMatchers = {};
-
   var messageFactories = {
     spy: function(txt) {
       return function(pass, spy) {
@@ -205,13 +203,17 @@
     };
   }
 
-  for (var i = 0, len = matchers.length; i < len; i++) {
-    var matcher = matchers[i];
-    jasmineSinonMatchers[matcher.jasmineName] = createMatcher(matcher);
+  function createJasmineSinonMatchers(matchers) {
+    var matcher, jasmineSinonMatchers = {};
+    for (var i = 0, len = matchers.length; i < len; i++) {
+      matcher = matchers[i];
+      jasmineSinonMatchers[matcher.jasmineName] = createMatcher(matcher);
+    }
+    return jasmineSinonMatchers;
   }
 
   beforeEach(function() {
-    jasmine.addMatchers(jasmineSinonMatchers);
+    jasmine.addMatchers(createJasmineSinonMatchers(matchers));
   });
 
 })(jasmine, jasmineRequire, beforeEach);

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -1,5 +1,3 @@
-/* global jasmine, jasmineRequire */
-
 (function(jasmine, jasmineRequire, beforeEach) {
   'use strict';
 
@@ -11,21 +9,24 @@
     sinon = window.sinon;
   }
 
-  var spyMatcherHash = {};
+  var newMatchers = {};
 
-  var messageFns = {
-    expectedSpyCallCount: function(txt) {
+  var messageFactories = {
+    spyWithCallCount: function(txt) {
       return function(pass, spy, otherArgs) {
-        return messageFns.expectedSpy(pass, spy, txt) + '. ' +
-          messageFns.callCount(spy);
+        return messageUtils.expectedSpy(pass, spy, txt) + '. ' +
+          messageUtils.callCount(spy);
       };
     },
-    expectedOtherArguments: function(txt) {
+    spyWithOtherArgs: function(txt) {
       return function(pass, spy, otherArgs) {
-        return messageFns.expectedSpy(pass, spy, txt) + ' ' +
-          messageFns.otherArgs(otherArgs);
+        return messageUtils.expectedSpy(pass, spy, txt) + ' ' +
+          messageUtils.otherArgs(otherArgs);
       };
-    },
+    }
+  };
+
+  var messageUtils = {
     expectedSpy: function(pass, spy, txt) {
       return 'Expected spy ' + jasmine.pp(spy) + ' ' +
         (pass ? 'not ' : '') + txt;
@@ -48,92 +49,92 @@
     {
       sinonName: 'called',
       jasmineName: 'toHaveBeenCalled',
-      message: messageFns.expectedSpyCallCount('to have been called')
+      message: messageFactories.spyWithCallCount('to have been called')
     },
     {
       sinonName: 'calledOnce',
       jasmineName: 'toHaveBeenCalledOnce',
-      message: messageFns.expectedSpyCallCount('to have been called once')
+      message: messageFactories.spyWithCallCount('to have been called once')
     },
     {
       sinonName: 'calledTwice',
       jasmineName: 'toHaveBeenCalledTwice',
-      message: messageFns.expectedSpyCallCount('to have been called twice')
+      message: messageFactories.spyWithCallCount('to have been called twice')
     },
     {
       sinonName: 'calledThrice',
       jasmineName: 'toHaveBeenCalledThrice',
-      message: messageFns.expectedSpyCallCount('to have been called thrice')
+      message: messageFactories.spyWithCallCount('to have been called thrice')
     },
     {
       sinonName: 'calledBefore',
       jasmineName: 'toHaveBeenCalledBefore',
-      message: messageFns.expectedOtherArguments('to have been called before')
+      message: messageFactories.spyWithOtherArgs('to have been called before')
     },
     {
       sinonName: 'calledAfter',
       jasmineName: 'toHaveBeenCalledAfter',
-      message: messageFns.expectedOtherArguments('to have been called after')
+      message: messageFactories.spyWithOtherArgs('to have been called after')
     },
     {
       sinonName: 'calledOn',
       jasmineName: 'toHaveBeenCalledOn',
-      message: messageFns.expectedOtherArguments('to have been called on')
+      message: messageFactories.spyWithOtherArgs('to have been called on')
     },
     {
       sinonName: 'alwaysCalledOn',
       jasmineName: 'toHaveBeenAlwaysCalledOn',
-      message: messageFns.expectedOtherArguments('to have been always called on')
+      message: messageFactories.spyWithOtherArgs('to have been always called on')
     },
     {
       sinonName: 'calledWith',
       jasmineName: 'toHaveBeenCalledWith',
-      message: messageFns.expectedOtherArguments('to have been called with')
+      message: messageFactories.spyWithOtherArgs('to have been called with')
     },
     {
       sinonName: 'alwaysCalledWith',
       jasmineName: 'toHaveBeenAlwaysCalledWith',
-      message: messageFns.expectedOtherArguments('to have been always called with')
+      message: messageFactories.spyWithOtherArgs('to have been always called with')
     },
     {
       sinonName: 'calledWithExactly',
       jasmineName: 'toHaveBeenCalledWithExactly',
-      message: messageFns.expectedOtherArguments('to have been called with exactly')
+      message: messageFactories.spyWithOtherArgs('to have been called with exactly')
     },
     {
       sinonName: 'alwaysCalledWithExactly',
       jasmineName: 'toHaveBeenAlwaysCalledWithExactly',
-      message: messageFns.expectedOtherArguments('to have been always called with exactly')
+      message: messageFactories.spyWithOtherArgs('to have been always called with exactly')
     },
     {
       sinonName: 'calledWithMatch',
       jasmineName: 'toHaveBeenCalledWithMatch',
-      message: messageFns.expectedOtherArguments('to have been called with match')
+      message: messageFactories.spyWithOtherArgs('to have been called with match')
     },
     {
       sinonName: 'alwaysCalledWithMatch',
       jasmineName: 'toHaveBeenAlwaysCalledWithMatch',
-      message: messageFns.expectedOtherArguments('to have been always called with match')
+      message: messageFactories.spyWithOtherArgs('to have been always called with match')
     },
     {
       sinonName: 'threw',
       jasmineName: 'toHaveThrown',
-      message: messageFns.expectedOtherArguments('to have thrown an error')
+      message: messageFactories.spyWithOtherArgs('to have thrown an error')
     },
     {
       sinonName: 'alwaysThrew',
       jasmineName: 'toHaveAlwaysThrown',
-      message: messageFns.expectedOtherArguments('to have always thrown an error')
+      message: messageFactories.spyWithOtherArgs('to have always thrown an error')
     },
     {
       sinonName: 'returned',
       jasmineName: 'toHaveReturned',
-      message: messageFns.expectedOtherArguments('to have returned')
+      message: messageFactories.spyWithOtherArgs('to have returned')
     },
     {
       sinonName: 'alwaysReturned',
       jasmineName: 'toHaveAlwaysReturned',
-      message: messageFns.expectedOtherArguments('to have always returned')
+      message: messageFactories.spyWithOtherArgs('to have always returned')
     }
   ];
 
@@ -184,11 +185,11 @@
 
   for (var i = 0, len = matchers.length; i < len; i++) {
     var matcher = matchers[i];
-    spyMatcherHash[matcher.jasmineName] = createMatcher(matcher);
+    newMatchers[matcher.jasmineName] = createMatcher(matcher);
   }
 
   beforeEach(function() {
-    jasmine.addMatchers(spyMatcherHash);
+    jasmine.addMatchers(newMatchers);
   });
 
 })(jasmine, jasmineRequire, beforeEach);

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -140,6 +140,11 @@
       message: messageFactories.spyWithOtherArgs('to have been never called with')
     },
     {
+      sinonName: 'neverCalledWithMatch',
+      jasmineName: 'toHaveBeenNeverCalledWithMatch',
+      message: messageFactories.spyWithOtherArgs('to have been never called with match')
+    },
+    {
       sinonName: 'threw',
       jasmineName: 'toHaveThrown',
       message: messageFactories.spyWithOtherArgs('to have thrown an error')

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -11,13 +11,36 @@
     sinon = window.sinon;
   }
 
+  var spyMatcherHash = {};
+
   var messageFns = {
-    callCount: function(matcher, spy) {
-      return '' + spy + ' was called ' + spy.callCount + ' times.';
+    expectedSpyCallCount: function(txt) {
+      return function(pass, spy, otherArgs) {
+        return messageFns.expectedSpy(pass, spy, txt) + '. ' +
+          messageFns.callCount(spy);
+      };
     },
-    otherSpy: function(matcher, spy, otherArgs) {
-      var other = otherArgs[0];
-      return (typeof other.toString === 'function') ? other.toString() : other;
+    expectedOtherArguments: function(txt) {
+      return function(pass, spy, otherArgs) {
+        return messageFns.expectedSpy(pass, spy, txt) + ' ' +
+          messageFns.otherArgs(otherArgs);
+      };
+    },
+    expectedSpy: function(pass, spy, txt) {
+      return 'Expected spy ' + jasmine.pp(spy) + ' ' +
+        (pass ? 'not ' : '') + txt;
+    },
+    callCount: function(spy) {
+      return 'Spy ' + jasmine.pp(spy) + ' was called ' + spy.callCount + ' times.';
+    },
+    otherArgs: function(otherArgs) {
+      if (!otherArgs || !otherArgs.length) {
+        return '';
+      } else if (otherArgs.length > 1) {
+        return jasmine.pp(otherArgs);
+      } else {
+        return jasmine.pp(otherArgs[0]);
+      }
     }
   };
 
@@ -25,62 +48,94 @@
     {
       sinonName: 'called',
       jasmineName: 'toHaveBeenCalled',
-      txt: 'to have been called',
-      passMessage: messageFns.callCount
+      message: messageFns.expectedSpyCallCount('to have been called')
     },
     {
       sinonName: 'calledOnce',
       jasmineName: 'toHaveBeenCalledOnce',
-      txt: 'to have been called once',
-      additionalMessage: messageFns.callCount
+      message: messageFns.expectedSpyCallCount('to have been called once')
     },
     {
       sinonName: 'calledTwice',
       jasmineName: 'toHaveBeenCalledTwice',
-      txt: 'to have been called twice',
-      additionalMessage: messageFns.callCount
+      message: messageFns.expectedSpyCallCount('to have been called twice')
     },
     {
       sinonName: 'calledThrice',
       jasmineName: 'toHaveBeenCalledThrice',
-      txt: 'to have been called thrice',
-      additionalMessage: messageFns.callCount
+      message: messageFns.expectedSpyCallCount('to have been called thrice')
     },
     {
       sinonName: 'calledBefore',
       jasmineName: 'toHaveBeenCalledBefore',
-      txt: 'to have been called before',
-      additionalMessage: messageFns.otherSpy
+      message: messageFns.expectedOtherArguments('to have been called before')
     },
     {
       sinonName: 'calledAfter',
       jasmineName: 'toHaveBeenCalledAfter',
-      txt: 'to have been called after',
-      additionalMessage: messageFns.otherSpy
+      message: messageFns.expectedOtherArguments('to have been called after')
     },
     {
       sinonName: 'calledOn',
       jasmineName: 'toHaveBeenCalledOn',
-      txt: 'to have been called on',
-      additionalMessage: messageFns.otherSpy
+      message: messageFns.expectedOtherArguments('to have been called on')
     },
     {
       sinonName: 'alwaysCalledOn',
       jasmineName: 'toHaveBeenAlwaysCalledOn',
-      txt: 'to have been always called on',
-      additionalMessage: messageFns.otherSpy
+      message: messageFns.expectedOtherArguments('to have been always called on')
+    },
+    {
+      sinonName: 'calledWith',
+      jasmineName: 'toHaveBeenCalledWith',
+      message: messageFns.expectedOtherArguments('to have been called with')
+    },
+    {
+      sinonName: 'alwaysCalledWith',
+      jasmineName: 'toHaveBeenAlwaysCalledWith',
+      message: messageFns.expectedOtherArguments('to have been always called with')
+    },
+    {
+      sinonName: 'calledWithExactly',
+      jasmineName: 'toHaveBeenCalledWithExactly',
+      message: messageFns.expectedOtherArguments('to have been called with exactly')
+    },
+    {
+      sinonName: 'alwaysCalledWithExactly',
+      jasmineName: 'toHaveBeenAlwaysCalledWithExactly',
+      message: messageFns.expectedOtherArguments('to have been always called with exactly')
+    },
+    {
+      sinonName: 'calledWithMatch',
+      jasmineName: 'toHaveBeenCalledWithMatch',
+      message: messageFns.expectedOtherArguments('to have been called with match')
+    },
+    {
+      sinonName: 'alwaysCalledWithMatch',
+      jasmineName: 'toHaveBeenAlwaysCalledWithMatch',
+      message: messageFns.expectedOtherArguments('to have been always called with match')
+    },
+    {
+      sinonName: 'threw',
+      jasmineName: 'toHaveThrown',
+      message: messageFns.expectedOtherArguments('to have thrown an error')
+    },
+    {
+      sinonName: 'alwaysThrew',
+      jasmineName: 'toHaveAlwaysThrown',
+      message: messageFns.expectedOtherArguments('to have always thrown an error')
+    },
+    {
+      sinonName: 'returned',
+      jasmineName: 'toHaveReturned',
+      message: messageFns.expectedOtherArguments('to have returned')
+    },
+    {
+      sinonName: 'alwaysReturned',
+      jasmineName: 'toHaveAlwaysReturned',
+      message: messageFns.expectedOtherArguments('to have always returned')
     }
   ];
-
-  // var spyMatchers = 'called calledOnce calledTwice calledThrice calledBefore calledAfter calledOn alwaysCalledOn calledWith alwaysCalledWith calledWithExactly alwaysCalledWithExactly calledWithMatch alwaysCalledWithMatch'.split(' ');
-  var matcherCount = matchers.length;
-  var spyMatcherHash = {};
-  // var unusualMatchers = {
-  //   "returned": "toHaveReturned",
-  //   "alwaysReturned": "toHaveAlwaysReturned",
-  //   "threw": "toHaveThrown",
-  //   "alwaysThrew": "toHaveAlwaysThrown"
-  // };
 
   function createCustomMatcher(arg, util, customEqualityTesters) {
     return sinon.match(function (val) {
@@ -120,37 +175,17 @@
 
           return {
             pass: pass,
-            message: generateMessage(pass, matcher, actual, args.slice(1))
+            message: matcher.message(pass, actual, args.slice(1))
           };
         }
       };
     };
   }
 
-  function generateMessage(passed, matcher, actual, otherArgs) {
-    var message = "Expected " + actual + " " +
-      (passed ? "not " : "") +
-      matcher.txt + ' ';
-    if (passed && matcher.passMessage) {
-      message += matcher.passMessage(matcher, actual, otherArgs);
-    }
-    if (!passed && matcher.notPassMessage) {
-      message += matcher.notPassMessage(matcher, actual, otherArgs);
-    }
-    if (matcher.additionalMessage) {
-      message += matcher.additionalMessage(matcher, actual, otherArgs);
-    }
-    return message;
-  }
-
-  for (var i = 0; i < matcherCount; i++) {
+  for (var i = 0, len = matchers.length; i < len; i++) {
     var matcher = matchers[i];
     spyMatcherHash[matcher.jasmineName] = createMatcher(matcher);
   }
-
-  // for (var j in unusualMatchers) {
-  //   spyMatcherHash[unusualMatchers[j]] = createMatcher(j, unusualMatchers[j]);
-  // }
 
   beforeEach(function() {
     jasmine.addMatchers(spyMatcherHash);

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -18,7 +18,7 @@
     spyWithCallCount: function(txt) {
       return function(pass, spy, otherArgs) {
         return messageUtils.expectedSpy(pass, spy, txt) + '. ' +
-          messageUtils.callCount(spy);
+          messageUtils.callCount(spy) + '.';
       };
     },
     spyWithOtherArgs: function(txt) {
@@ -215,5 +215,9 @@
   beforeEach(function() {
     jasmine.addMatchers(createJasmineSinonMatchers(matchers));
   });
+
+  jasmine.jasmineSinon = {
+    messageFactories: messageFactories
+  };
 
 })(jasmine, jasmineRequire, beforeEach);

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -9,7 +9,7 @@
     sinon = window.sinon;
   }
 
-  var newMatchers = {};
+  var jasmineSinonMatchers = {};
 
   var messageFactories = {
     spy: function(txt) {
@@ -33,19 +33,13 @@
 
   var messageUtils = {
     expectedSpy: function(pass, spy, txt) {
-      return 'Expected "' + spy + '" ' +
-        (pass ? 'not ' : '') + txt;
+      var not = (pass ? 'not ' : '');
+      var printf = spy.printf || sinon.spy.printf;
+      return printf.call(spy, 'Expected spy "%n" %1%2', not, txt);
     },
     callCount: function(spy) {
-      var msg = '"' + spy + '" ';
-      if (spy.callCount >= 2) {
-        msg += 'was called ' + spy.callCount + ' times.';
-      } else if (spy.callCount === 1) {
-        msg += 'was called once.';
-      } else if (spy.callCount === 0) {
-        msg += 'was not called.';
-      }
-      return msg;
+      var printf = spy.printf || sinon.spy.printf;
+      return printf.call(spy, '"%n" was called %c');
     },
     otherArgs: function(otherArgs) {
       if (!otherArgs || !otherArgs.length) {
@@ -213,11 +207,11 @@
 
   for (var i = 0, len = matchers.length; i < len; i++) {
     var matcher = matchers[i];
-    newMatchers[matcher.jasmineName] = createMatcher(matcher);
+    jasmineSinonMatchers[matcher.jasmineName] = createMatcher(matcher);
   }
 
   beforeEach(function() {
-    jasmine.addMatchers(newMatchers);
+    jasmine.addMatchers(jasmineSinonMatchers);
   });
 
 })(jasmine, jasmineRequire, beforeEach);

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -1,76 +1,156 @@
 /* global jasmine, jasmineRequire */
 
-'use strict';
-
 (function(jasmine, jasmineRequire, beforeEach) {
+  'use strict';
 
-  var sinon = (typeof require === 'function' && typeof module === 'object') ? require('sinon') : window.sinon,
-    spyMatchers = 'called calledOnce calledTwice calledThrice calledBefore calledAfter calledOn alwaysCalledOn calledWith alwaysCalledWith calledWithExactly alwaysCalledWithExactly calledWithMatch alwaysCalledWithMatch'.split(' '),
-    matcherCount = spyMatchers.length,
-    spyMatcherHash = {},
-    unusualMatchers = {
-      "returned": "toHaveReturned",
-      "alwaysReturned": "toHaveAlwaysReturned",
-      "threw": "toHaveThrown",
-      "alwaysThrew": "toHaveAlwaysThrown"
+  var sinon;
+
+  if (typeof require === 'function' && typeof module === 'object') {
+    sinon = require('sinon');
+  } else {
+    sinon = window.sinon;
+  }
+
+  var messageFns = {
+    callCount: function(matcher, spy) {
+      return '' + spy + ' was called ' + spy.callCount + ' times.';
     },
+    otherSpy: function(matcher, spy, otherArgs) {
+      var other = otherArgs[0];
+      return (typeof other.toString === 'function') ? other.toString() : other;
+    }
+  };
 
-    createCustomMatcher = function(arg, util, customEqualityTesters) {
-      return sinon.match(function (val) {
-        return util.equals(val, arg, customEqualityTesters);
-      });
+  var matchers = [
+    {
+      sinonName: 'called',
+      jasmineName: 'toHaveBeenCalled',
+      txt: 'to have been called',
+      passMessage: messageFns.callCount
     },
+    {
+      sinonName: 'calledOnce',
+      jasmineName: 'toHaveBeenCalledOnce',
+      txt: 'to have been called once',
+      additionalMessage: messageFns.callCount
+    },
+    {
+      sinonName: 'calledTwice',
+      jasmineName: 'toHaveBeenCalledTwice',
+      txt: 'to have been called twice',
+      additionalMessage: messageFns.callCount
+    },
+    {
+      sinonName: 'calledThrice',
+      jasmineName: 'toHaveBeenCalledThrice',
+      txt: 'to have been called thrice',
+      additionalMessage: messageFns.callCount
+    },
+    {
+      sinonName: 'calledBefore',
+      jasmineName: 'toHaveBeenCalledBefore',
+      txt: 'to have been called before',
+      additionalMessage: messageFns.otherSpy
+    },
+    {
+      sinonName: 'calledAfter',
+      jasmineName: 'toHaveBeenCalledAfter',
+      txt: 'to have been called after',
+      additionalMessage: messageFns.otherSpy
+    },
+    {
+      sinonName: 'calledOn',
+      jasmineName: 'toHaveBeenCalledOn',
+      txt: 'to have been called on',
+      additionalMessage: messageFns.otherSpy
+    },
+    {
+      sinonName: 'alwaysCalledOn',
+      jasmineName: 'toHaveBeenAlwaysCalledOn',
+      txt: 'to have been always called on',
+      additionalMessage: messageFns.otherSpy
+    }
+  ];
 
-    getMatcherFunction = function(sinonName, jasmineName) {
-      var original = jasmineRequire[jasmineName];
-      return function (util, customEqualityTesters) {
-        return {
-          compare: function() {
-            var compare, sinonProperty;
-            var args = [].slice.call(arguments, 0);
-            var arg;
-            var pass;
-            var actual = args[0];
+  // var spyMatchers = 'called calledOnce calledTwice calledThrice calledBefore calledAfter calledOn alwaysCalledOn calledWith alwaysCalledWith calledWithExactly alwaysCalledWithExactly calledWithMatch alwaysCalledWithMatch'.split(' ');
+  var matcherCount = matchers.length;
+  var spyMatcherHash = {};
+  // var unusualMatchers = {
+  //   "returned": "toHaveReturned",
+  //   "alwaysReturned": "toHaveAlwaysReturned",
+  //   "threw": "toHaveThrown",
+  //   "alwaysThrew": "toHaveAlwaysThrown"
+  // };
 
-            if (jasmine.isSpy(actual) && original) {
-              compare = original(jasmine)(util, customEqualityTesters).compare;
-              return compare.apply(null, args);
-            }
+  function createCustomMatcher(arg, util, customEqualityTesters) {
+    return sinon.match(function (val) {
+      return util.equals(val, arg, customEqualityTesters);
+    });
+  }
 
-            sinonProperty = actual[sinonName];
+  function createMatcher(matcher) {
+    var original = jasmineRequire[matcher.jasmineName];
 
-            for (var i = 0, len = args.length; i < len; i++) {
-              arg = args[i];
-              if (arg && (typeof arg.jasmineMatches === 'function' || arg instanceof jasmine.ObjectContaining)) {
-                args[i] = createCustomMatcher(arg, util, customEqualityTesters);
-              }
-            }
+    return function (util, customEqualityTesters) {
+      return {
+        compare: function() {
+          var compare, sinonProperty, arg, pass;
+          var args = [].slice.call(arguments, 0);
+          var actual = args[0];
 
-            if (typeof sinonProperty === 'function') {
-              pass = sinonProperty.apply(actual, args.slice(1));
-            } else {
-              pass = sinonProperty;
-            }
-
-            return {
-              pass: pass,
-              message: ""
-            };
+          if (jasmine.isSpy(actual) && original) {
+            compare = original(jasmine)(util, customEqualityTesters).compare;
+            return compare.apply(null, args);
           }
-        };
+
+          for (var i = 0, len = args.length; i < len; i++) {
+            arg = args[i];
+            if (arg && (typeof arg.jasmineMatches === 'function' || arg instanceof jasmine.ObjectContaining)) {
+              args[i] = createCustomMatcher(arg, util, customEqualityTesters);
+            }
+          }
+
+          sinonProperty = actual[matcher.sinonName];
+
+          if (typeof sinonProperty === 'function') {
+            pass = sinonProperty.apply(actual, args.slice(1));
+          } else {
+            pass = sinonProperty;
+          }
+
+          return {
+            pass: pass,
+            message: generateMessage(pass, matcher, actual, args.slice(1))
+          };
+        }
       };
     };
+  }
+
+  function generateMessage(passed, matcher, actual, otherArgs) {
+    var message = "Expected " + actual + " " +
+      (passed ? "not " : "") +
+      matcher.txt + ' ';
+    if (passed && matcher.passMessage) {
+      message += matcher.passMessage(matcher, actual, otherArgs);
+    }
+    if (!passed && matcher.notPassMessage) {
+      message += matcher.notPassMessage(matcher, actual, otherArgs);
+    }
+    if (matcher.additionalMessage) {
+      message += matcher.additionalMessage(matcher, actual, otherArgs);
+    }
+    return message;
+  }
 
   for (var i = 0; i < matcherCount; i++) {
-    var sinonName = spyMatchers[i],
-      jasmineName = "toHaveBeen" + sinonName.charAt(0).toUpperCase() + sinonName.slice(1);
-
-    spyMatcherHash[jasmineName] = getMatcherFunction(sinonName, jasmineName);
+    var matcher = matchers[i];
+    spyMatcherHash[matcher.jasmineName] = createMatcher(matcher);
   }
 
-  for (var j in unusualMatchers) {
-    spyMatcherHash[unusualMatchers[j]] = getMatcherFunction(j, unusualMatchers[j]);
-  }
+  // for (var j in unusualMatchers) {
+  //   spyMatcherHash[unusualMatchers[j]] = createMatcher(j, unusualMatchers[j]);
+  // }
 
   beforeEach(function() {
     jasmine.addMatchers(spyMatcherHash);

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -1,12 +1,12 @@
-/* global jasmine */
+/* global jasmine, jasmineRequire */
 
 'use strict';
 
-(function(jasmine, beforeEach) {
+(function(jasmine, jasmineRequire, beforeEach) {
 
   var sinon = (typeof require === 'function' && typeof module === 'object') ? require('sinon') : window.sinon,
     spyMatchers = 'called calledOnce calledTwice calledThrice calledBefore calledAfter calledOn alwaysCalledOn calledWith alwaysCalledWith calledWithExactly alwaysCalledWithExactly calledWithMatch alwaysCalledWithMatch'.split(' '),
-    i = spyMatchers.length,
+    matcherCount = spyMatchers.length,
     spyMatcherHash = {},
     unusualMatchers = {
       "returned": "toHaveReturned",
@@ -15,36 +15,57 @@
       "alwaysThrew": "toHaveAlwaysThrown"
     },
 
-    createCustomMatcher = function(arg) {
+    createCustomMatcher = function(arg, util, customEqualityTesters) {
       return sinon.match(function (val) {
-        return jasmine.getEnv().equals_(val, arg);
+        return util.equals(val, arg, customEqualityTesters);
       });
     },
 
-    getMatcherFunction = function(sinonName, matcherName) {
-      var original = jasmine.Matchers.prototype[matcherName];
-      return function () {
-        if (jasmine.isSpy(this.actual) && original) {
-          return original.apply(this, arguments);
-        }
-        var sinonProperty = this.actual[sinonName];
-        var args = Array.prototype.slice.call(arguments);
+    getMatcherFunction = function(sinonName, jasmineName) {
+      var original = jasmineRequire[jasmineName];
+      return function (util, customEqualityTesters) {
+        return {
+          compare: function() {
+            var compare, sinonProperty;
+            var args = [].slice.call(arguments, 0);
+            var arg;
+            var pass;
+            var actual = args[0];
 
-        for (var i = 0; i < args.length; i++) {
-          if (args[i] && (typeof args[i].jasmineMatches === 'function' || args[i] instanceof jasmine.Matchers.ObjectContaining)) {
-            args[i] = createCustomMatcher(args[i]);
+            if (jasmine.isSpy(actual) && original) {
+              compare = original(jasmine)(util, customEqualityTesters).compare;
+              return compare.apply(null, args);
+            }
+
+            sinonProperty = actual[sinonName];
+
+            for (var i = 0, len = args.length; i < len; i++) {
+              arg = args[i];
+              if (arg && (typeof arg.jasmineMatches === 'function' || arg instanceof jasmine.ObjectContaining)) {
+                args[i] = createCustomMatcher(arg, util, customEqualityTesters);
+              }
+            }
+
+            if (typeof sinonProperty === 'function') {
+              pass = sinonProperty.apply(actual, args.slice(1));
+            } else {
+              pass = sinonProperty;
+            }
+
+            return {
+              pass: pass,
+              message: ""
+            };
           }
-        }
-
-        return (typeof sinonProperty === 'function') ? sinonProperty.apply(this.actual, args) : sinonProperty;
+        };
       };
     };
 
-  while(i--) {
+  for (var i = 0; i < matcherCount; i++) {
     var sinonName = spyMatchers[i],
-      matcherName = "toHaveBeen" + sinonName.charAt(0).toUpperCase() + sinonName.slice(1);
+      jasmineName = "toHaveBeen" + sinonName.charAt(0).toUpperCase() + sinonName.slice(1);
 
-    spyMatcherHash[matcherName] = getMatcherFunction(sinonName, matcherName);
+    spyMatcherHash[jasmineName] = getMatcherFunction(sinonName, jasmineName);
   }
 
   for (var j in unusualMatchers) {
@@ -52,7 +73,7 @@
   }
 
   beforeEach(function() {
-    this.addMatchers(spyMatcherHash);
+    jasmine.addMatchers(spyMatcherHash);
   });
 
-})(jasmine, beforeEach);
+})(jasmine, jasmineRequire, beforeEach);

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -135,6 +135,11 @@
       message: messageFactories.spy('to have been called with new')
     },
     {
+      sinonName: 'neverCalledWith',
+      jasmineName: 'toHaveBeenNeverCalledWith',
+      message: messageFactories.spyWithOtherArgs('to have been never called with')
+    },
+    {
       sinonName: 'threw',
       jasmineName: 'toHaveThrown',
       message: messageFactories.spyWithOtherArgs('to have thrown an error')

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -1,4 +1,4 @@
-(function(jasmine, jasmineRequire, beforeEach) {
+(function(jasmine, beforeEach) {
   'use strict';
 
   var sinon;
@@ -165,18 +165,17 @@
   }
 
   function createMatcher(matcher) {
-    var original = jasmineRequire[matcher.jasmineName];
+    var original = jasmine.matchers[matcher.jasmineName];
 
     return function (util, customEqualityTesters) {
       return {
         compare: function() {
-          var compare, sinonProperty, arg, pass;
+          var sinonProperty, arg, pass;
           var args = [].slice.call(arguments, 0);
           var actual = args[0];
 
           if (jasmine.isSpy(actual) && original) {
-            compare = original(jasmine)(util, customEqualityTesters).compare;
-            return compare.apply(null, args);
+            return original(util, customEqualityTesters).compare.apply(null, args);
           }
 
           for (var i = 0, len = args.length; i < len; i++) {
@@ -220,4 +219,4 @@
     messageFactories: messageFactories
   };
 
-})(jasmine, jasmineRequire, beforeEach);
+})(jasmine, beforeEach);

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -12,6 +12,11 @@
   var newMatchers = {};
 
   var messageFactories = {
+    spy: function(txt) {
+      return function(pass, spy) {
+        return messageUtils.expectedSpy(pass, spy, txt) + '.';
+      };
+    },
     spyWithCallCount: function(txt) {
       return function(pass, spy, otherArgs) {
         return messageUtils.expectedSpy(pass, spy, txt) + '. ' +
@@ -123,6 +128,11 @@
       sinonName: 'alwaysCalledWithMatch',
       jasmineName: 'toHaveBeenAlwaysCalledWithMatch',
       message: messageFactories.spyWithOtherArgs('to have been always called with match')
+    },
+    {
+      sinonName: 'calledWithNew',
+      jasmineName: 'toHaveBeenCalledWithNew',
+      message: messageFactories.spy('to have been called with new')
     },
     {
       sinonName: 'threw',

--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -28,11 +28,19 @@
 
   var messageUtils = {
     expectedSpy: function(pass, spy, txt) {
-      return 'Expected spy ' + jasmine.pp(spy) + ' ' +
+      return 'Expected "' + spy + '" ' +
         (pass ? 'not ' : '') + txt;
     },
     callCount: function(spy) {
-      return 'Spy ' + jasmine.pp(spy) + ' was called ' + spy.callCount + ' times.';
+      var msg = '"' + spy + '" ';
+      if (spy.callCount >= 2) {
+        msg += 'was called ' + spy.callCount + ' times.';
+      } else if (spy.callCount === 1) {
+        msg += 'was called once.';
+      } else if (spy.callCount === 0) {
+        msg += 'was not called.';
+      }
+      return msg;
     },
     otherArgs: function(otherArgs) {
       if (!otherArgs || !otherArgs.length) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-karma": "~0.8.3",
     "grunt-jasmine-node": "~0.2.1",
-    "karma-jasmine": "~0.1.5",
+    "karma-jasmine": "~0.2.0",
     "karma-chrome-launcher": "~0.1.3",
     "karma-firefox-launcher": "~0.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "grunt-jasmine-node": "~0.2.1",
     "karma-jasmine": "~0.2.0",
     "karma-chrome-launcher": "~0.1.3",
-    "karma-firefox-launcher": "~0.1.3"
+    "karma-firefox-launcher": "~0.1.3",
+    "jasmine-node": "~2.0.0-beta4",
+    "grunt-shell": "~0.7.0"
   },
   "dependencies": {
     "sinon": ">= 1.7.1"

--- a/spec/jasmine-matchers-compatibility.spec.js
+++ b/spec/jasmine-matchers-compatibility.spec.js
@@ -3,8 +3,8 @@ if (typeof require === 'function' && typeof module === 'object') {
   var jasmineSinon = require('../lib/jasmine-sinon.js');
 }
 
-describe('sinon matchers should support jasmine matchers', function() {
-  it('jasmine.any()', function () {
+describe('jasmine matcher', function() {
+  it('jasmine.any() is supported', function () {
     var spy = sinon.spy();
     spy('abc');
     spy(new Date());

--- a/spec/message-factories.spec.js
+++ b/spec/message-factories.spec.js
@@ -1,0 +1,58 @@
+if (typeof require === 'function' && typeof module === 'object') {
+  var sinon = require('sinon');
+  var jasmineSinon = require('../lib/jasmine-sinon.js');
+}
+
+describe('message factories', function() {
+  beforeEach(function () {
+    this.spy = sinon.spy(function mySpy() {});
+  });
+
+  describe('#spy', function () {
+    beforeEach(function () {
+      this.subject = jasmine.jasmineSinon.messageFactories.spy('to have been called');
+    });
+
+    it('formats the message correctly', function () {
+      expect(this.subject(false, this.spy)).toEqual('Expected spy "mySpy" to have been called.');
+    });
+
+    it('formats the message correctly with "not"', function () {
+      expect(this.subject(true, this.spy)).toEqual('Expected spy "mySpy" not to have been called.');
+    });
+  });
+
+  describe('#spyWithCallCount', function () {
+    beforeEach(function () {
+      this.subject = jasmine.jasmineSinon.messageFactories.spyWithCallCount('to have been called once');
+      this.spy();
+    });
+
+    it('formats the message correctly', function () {
+      expect(this.subject(false, this.spy)).
+        toEqual('Expected spy "spy" to have been called once. "spy" was called once.');
+    });
+
+    it('formats the message correctly with "not"', function () {
+      expect(this.subject(true, this.spy)).
+        toEqual('Expected spy "spy" not to have been called once. "spy" was called once.');
+    });
+  });
+
+  describe('#spyWithOtherArgs', function () {
+    beforeEach(function () {
+      this.subject = jasmine.jasmineSinon.messageFactories.spyWithOtherArgs('to have been called with');
+      this.otherArgs = ['a', { foo: 'bar' }];
+    });
+
+    it('formats the message correctly', function () {
+      expect(this.subject(false, this.spy, this.otherArgs)).
+        toEqual('Expected spy "mySpy" to have been called with [ \'a\', { foo : \'bar\' } ]');
+    });
+
+    it('formats the message correct with "not"', function () {
+      expect(this.subject(true, this.spy, this.otherArgs)).
+        toEqual('Expected spy "mySpy" not to have been called with [ \'a\', { foo : \'bar\' } ]');
+    });
+  });
+});

--- a/spec/overwritten-jasmine-matchers.spec.js
+++ b/spec/overwritten-jasmine-matchers.spec.js
@@ -11,7 +11,7 @@ describe('jasmine matchers gracefully overridden', function() {
         this.methodVal = val;
       }
     };
-    spyOn(this.api, 'myMethod').andCallThrough();
+    spyOn(this.api, 'myMethod').and.callThrough();
   });
 
   describe('toHaveBeenCalled', function() {

--- a/spec/spy-matchers.spec.js
+++ b/spec/spy-matchers.spec.js
@@ -285,6 +285,20 @@ describe('spy matchers', function() {
     });
   });
 
+  describe('calledWithNew', function() {
+    it('should match when spy called with new operator', function() {
+      var newSpy = new this.spy();
+      expect(this.spy.calledWithNew()).toBeTruthy();
+      expect(this.spy).toHaveBeenCalledWithNew();
+    });
+
+    it('should not match when spy not called with new', function() {
+      this.spy();
+      expect(this.spy.calledWithNew()).toBeFalsy();
+      expect(this.spy).not.toHaveBeenCalledWithNew();
+    })
+  });
+
   describe('threw/toHaveThrown', function() {
     beforeEach(function() {
       this.spy = sinon.spy.create();

--- a/spec/spy-matchers.spec.js
+++ b/spec/spy-matchers.spec.js
@@ -154,11 +154,16 @@ describe('spy matchers', function() {
 
   describe('calledOn/toHaveBeenCalledOn', function() {
     it('should match when spy called on expected object', function() {
-      expect(this.spy.calledOn(this)).toBeFalsy();
-      expect(this.spy).not.toHaveBeenCalledOn(this);
-      this.spy.call(this);
-      expect(this.spy.calledOn(this)).toBeTruthy();
-      expect(this.spy).toHaveBeenCalledOn(this);
+      var obj = {
+        toString: function() {
+          return 'my object'
+        }
+      };
+      expect(this.spy.calledOn(obj)).toBeFalsy();
+      expect(this.spy).not.toHaveBeenCalledOn(obj);
+      this.spy.call(obj);
+      expect(this.spy.calledOn(obj)).toBeTruthy();
+      expect(this.spy).toHaveBeenCalledOn(obj);
     });
   });
 

--- a/spec/spy-matchers.spec.js
+++ b/spec/spy-matchers.spec.js
@@ -316,6 +316,22 @@ describe('spy matchers', function() {
     });
   });
 
+  describe('neverCalledWithMatch', function() {
+    it('should match when the spy was never called with matching arguments', function() {
+      var obj = {foo: '1', bar: '2'};
+      this.spy(obj);
+      expect(this.spy.neverCalledWithMatch({baz: '1'})).toBeTruthy();
+      expect(this.spy).toHaveBeenNeverCalledWithMatch({baz: '1'});
+    });
+
+    it('should not match when the spy was called with matching arguments', function() {
+      var obj = {foo: '1', bar: '2'};
+      this.spy(obj);
+      expect(this.spy.neverCalledWithMatch({foo: '1'})).toBeFalsy();
+      expect(this.spy).not.toHaveBeenNeverCalledWithMatch({foo:'1'});
+    });
+  });
+
   describe('threw/toHaveThrown', function() {
     beforeEach(function() {
       this.spy = sinon.spy.create();

--- a/spec/spy-matchers.spec.js
+++ b/spec/spy-matchers.spec.js
@@ -299,6 +299,23 @@ describe('spy matchers', function() {
     })
   });
 
+  describe('neverCalledWith', function() {
+    it('should match when the spy was never called with the argument', function() {
+      this.spy('foo');
+      this.spy('bar');
+      expect(this.spy.neverCalledWith('baz')).toBeTruthy();
+      expect(this.spy).toHaveBeenNeverCalledWith('baz');
+    });
+
+    it('should not match when the spy was called with the argument', function() {
+      this.spy('foo');
+      this.spy('bar');
+      this.spy('baz');
+      expect(this.spy.neverCalledWith('baz')).toBeFalsy();
+      expect(this.spy).not.toHaveBeenNeverCalledWith('baz'); // OMG YUCK
+    });
+  });
+
   describe('threw/toHaveThrown', function() {
     beforeEach(function() {
       this.spy = sinon.spy.create();

--- a/spec/spy-matchers.spec.js
+++ b/spec/spy-matchers.spec.js
@@ -181,11 +181,9 @@ describe('spy matchers', function() {
       expect(this.spy.alwaysCalledOn(this)).toBeFalsy();
       expect(this.spy).not.toHaveBeenAlwaysCalledOn(this);
     });
-
   });
 
   describe('calledWith/toHaveBeenCalledWith', function() {
-
     it('should match when spy called with argument', function() {
       this.spy('arg1');
       expect(this.spy.calledWith('arg1')).toBeTruthy();
@@ -197,11 +195,9 @@ describe('spy matchers', function() {
       expect(this.spy.calledWith('arg2')).toBeFalsy();
       expect(this.spy).not.toHaveBeenCalledWith('arg2');
     });
-
   });
 
   describe('alwaysCalledWith/toHaveBeenAlwaysCalledWith', function() {
-
     it('should match when spy always called with argument', function() {
       this.spy('arg1');
       this.spy('arg1', 'arg2');
@@ -215,11 +211,9 @@ describe('spy matchers', function() {
       expect(this.spy.alwaysCalledWith('arg1')).toBeFalsy();
       expect(this.spy).not.toHaveBeenAlwaysCalledWith('arg');
     });
-
   });
 
   describe('calledWithExactly/toHaveBeenCalledWithExactly', function() {
-
     it('should match when spy called with exact argument set', function() {
       this.spy('arg1', 'arg2');
       expect(this.spy.calledWithExactly('arg1', 'arg2')).toBeTruthy();
@@ -231,11 +225,9 @@ describe('spy matchers', function() {
       expect(this.spy.calledWithExactly('arg1', 'arg2')).toBeFalsy();
       expect(this.spy).not.toHaveBeenCalledWithExactly('arg1', 'arg2');
     });
-
   });
 
   describe('alwaysCalledWithExactly/toHaveBeenAlwaysCalledWithExactly', function() {
-
     it('should match when spy always called with exact argument set', function() {
       this.spy('arg1', 'arg2');
       this.spy('arg1', 'arg2');
@@ -249,11 +241,9 @@ describe('spy matchers', function() {
       expect(this.spy.alwaysCalledWithExactly('arg1','arg2')).toBeFalsy();
       expect(this.spy).not.toHaveBeenAlwaysCalledWithExactly('arg1','arg2');
     });
-
   });
 
   describe('calledWithMatch/toHaveBeenCalledWithMatch', function() {
-
     it('should match when spy called with arguments that match', function() {
       this.spy({arg1:'one', arg2:'two'});
       expect(this.spy.calledWithMatch({arg1:'one'})).toBeTruthy();
@@ -269,12 +259,9 @@ describe('spy matchers', function() {
       expect(this.spy.calledWithMatch({arg1:'two', arg2:'two'})).toBeFalsy();
       expect(this.spy).not.toHaveBeenCalledWithMatch({arg1:'two', arg2:'two'});
     });
-
   });
 
-
   describe('alwaysCalledWithMatch/toHaveBeenAlwaysCalledWithMatch', function() {
-
     it('should match when spy always called with matching arguments set', function() {
       this.spy({arg1:'one', arg2:'two'});
       this.spy({arg1:'one', arg2:'two'});
@@ -296,11 +283,9 @@ describe('spy matchers', function() {
       expect(this.spy.alwaysCalledWithMatch({arg2:'two'})).toBeFalsy();
       expect(this.spy).not.toHaveBeenAlwaysCalledWithMatch({arg2:'two'});
     });
-
   });
 
   describe('threw/toHaveThrown', function() {
-
     beforeEach(function() {
       this.spy = sinon.spy.create();
 


### PR DESCRIPTION
- Add support for newer sinonjs spy matcher methods
- Refactor to support Jasmine 2.0 API modifications
- Declarative matcher generation with shared message utilities
