### PR TITLE
Add calls to failure messages as done by sinon.assert

### DIFF
--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -12,7 +12,9 @@
   var messageFactories = {
     spy: function(txt) {
       return function(pass, spy) {
-        return messageUtils.expectedSpy(pass, spy, txt) + '.';
+        var calls = messageUtils.calls(spy);
+        return messageUtils.expectedSpy(pass, spy, txt) +
+            calls + (calls.length === 0 ? '.' : '');
       };
     },
     spyWithCallCount: function(txt) {
@@ -24,7 +26,8 @@
     spyWithOtherArgs: function(txt) {
       return function(pass, spy, otherArgs) {
         return messageUtils.expectedSpy(pass, spy, txt) + ' ' +
-          messageUtils.otherArgs(otherArgs);
+          messageUtils.otherArgs(otherArgs) +
+          messageUtils.calls(spy);
       };
     }
   };
@@ -37,7 +40,12 @@
     },
     callCount: function(spy) {
       var printf = spy.printf || sinon.spy.printf;
-      return printf.call(spy, '"%n" was called %c');
+      return printf.call(spy, '"%n" was called %c:%C');
+    },
+    calls: function(spy) {
+        var printf = spy.printf || sinon.spy.printf;
+        var text = printf.call(spy, '%C');
+        return (text.length > 0 ? ':' + text : '');
     },
     otherArgs: function(otherArgs) {
       if (!otherArgs || !otherArgs.length) {

--- a/spec/message-factories.spec.js
+++ b/spec/message-factories.spec.js
@@ -30,12 +30,12 @@ describe('message factories', function() {
 
     it('formats the message correctly', function () {
       expect(this.subject(false, this.spy)).
-        toEqual('Expected spy "spy" to have been called once. "spy" was called once.');
+        toEqual('Expected spy "spy" to have been called once. "spy" was called once:\n    spy().');
     });
 
     it('formats the message correctly with "not"', function () {
       expect(this.subject(true, this.spy)).
-        toEqual('Expected spy "spy" not to have been called once. "spy" was called once.');
+        toEqual('Expected spy "spy" not to have been called once. "spy" was called once:\n    spy().');
     });
   });
 


### PR DESCRIPTION
This was something that people complained about when we switched our
Jasmine tests from using sinon.assert to jasmine-sinon expectations
after the Jasmine 2.x upgrade.
