### PR TITLE
use asymmetricMatch to check for fuzzy matchers

### DIFF
--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -180,7 +180,7 @@
 
           for (var i = 0, len = args.length; i < len; i++) {
             arg = args[i];
-            if (arg && (typeof arg.jasmineMatches === 'function' || arg instanceof jasmine.ObjectContaining)) {
+            if (arg && (typeof arg.asymmetricMatch === 'function' || typeof arg.jasmineMatches === 'function' || arg instanceof jasmine.ObjectContaining)) {
               args[i] = createCustomMatcher(arg, util, customEqualityTesters);
             }
           }


### PR DESCRIPTION
Jasmine 2.2.0 have renamed jasmineMatches to asymmetricMatch which breaks
jasmine.any() matchers.

See the change here: https://github.com/jasmine/jasmine/commit/6bd98cb2ab88f7a8cdc7fca8f40da79d36f50c5e
