### PR TITLE
Avoid "(empty string)" printed in failure messages

### DIFF
--- a/lib/jasmine-sinon.js
+++ b/lib/jasmine-sinon.js
@@ -33,7 +33,7 @@
     expectedSpy: function(pass, spy, txt) {
       var not = (pass ? 'not ' : '');
       var printf = spy.printf || sinon.spy.printf;
-      return printf.call(spy, 'Expected spy "%n" %1%2', not, txt);
+      return printf.call(spy, 'Expected spy "%n" ' + not + '%1', txt);
     },
     callCount: function(spy) {
       var printf = spy.printf || sinon.spy.printf;


### PR DESCRIPTION
Fixes #42; some `printf` functions print the `''` from the `not` variable as `(empty string)` which results in an unexpected failure message.